### PR TITLE
Gemmciro 82 Add OneTrust token, remove Sentry

### DIFF
--- a/layouts/partials/head-scripts.html
+++ b/layouts/partials/head-scripts.html
@@ -33,7 +33,7 @@ function OptanonWrapper() { { window.dataLayer.push({ event: 'OneTrustGroupsUpda
 <!--  crossorigin="anonymous"-->
 <!--&gt;</script>-->
 
-<!--<script>-->
+<script>
 <!--Sentry.init({-->
 <!--  dsn: "https://91138cf7f17842fd8a57d45372bf538c@o448817.ingest.sentry.io/5712977",-->
 <!--  integrations: [new Sentry.Integrations.BrowserTracing()],-->


### PR DESCRIPTION
Add the gemfire.dev OneTrust token and removes calls to Sentry until a gemfire.dev Sentry token can be provided.