### PR TITLE
GEMMICRO-129: Fix Title of Cache Loader Example

### DIFF
--- a/content/examples/java/using-a-cache-loader.md
+++ b/content/examples/java/using-a-cache-loader.md
@@ -1,5 +1,5 @@
 ---
-title: Using A Cache Listener
+title: Using A Cache Loader
 date: '2023-04-03'
 lastmod: '2023-04-03'
 repo: https://github.com/gemfire/gemfire-examples/blob/main/feature-examples/loader


### PR DESCRIPTION
The title metadata is incorrect, refers to "Listener" instead of "Loader".