### PR TITLE
GEMMICRO-131: make vmware-by-broadcom logo white in dark mode

### DIFF
--- a/assets/icons/logo.svg
+++ b/assets/icons/logo.svg
@@ -11,8 +11,11 @@
         opacity: 0;
       }
 
+      .cls-1 {
+        fill: #fff;
+      }
       .cls-3 {
-        fill: #727175;
+        fill: #fff;
       }
     </style>
   </defs>

--- a/assets/scss/light-theme.scss
+++ b/assets/scss/light-theme.scss
@@ -5,8 +5,11 @@ body {
    background-color: white !important;
    color: #61717d !important;
 }
- body .navbar-dark .navbar-brand .navbar-logo svg .cls-1 {
-   fill: #717074 !important;
+.navbar-logo svg .cls-3, .footer-logo svg .cls-3 {
+   fill: #727175 !important;
+}
+.navbar-logo svg .cls-1, .footer-logo svg .cls-1 {
+   fill: #28333c !important;
 }
 nav .drop-menu{
     background-color: white !important;


### PR DESCRIPTION
theory of operation for the microsite is all assets need to be configured for dark mode by default, then modified by light-theme.scss
dark mode is controlled by a custom toggle on the top-right corner of the microsite (not the browser/OS setting)

so, this PR makes the logo white by default, then updates light-theme to restore the original colors